### PR TITLE
Adds Marius Schulz to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Another take on this idea from Stu Robson: https://github.com/sturobson/myRSS
 - [Lynn Fisher](https://lynnandtonic.com/)
 - [Marco's Accessibility Blog](https://www.marcozehe.de/)
 - [marcus.io](https://marcus.io/) [[RSS](https://marcus.io/feed)]
+- [Marius Schulz](https://mariusschulz.com/)
 - [Matt Hagner](https://www.matthagner.com/)
 - [Mathias Bynens](https://mathiasbynens.be/notes)
 - [matthiasott.com](https://matthiasott.com) [[RSS](https://matthiasott.com/rss)]


### PR DESCRIPTION
Adds [mariusschulz.com](https://mariusschulz.com/) to the list.