### PR TITLE
Update link/name to Emma Bostian's website

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Another take on this idea from Stu Robson: https://github.com/sturobson/myRSS
 - [decadecity.net](https://decadecity.net/)
 - [deliciousreverie.co.uk](https://deliciousreverie.co.uk/) [[RSS](https://deliciousreverie.co.uk/index.xml)]
 - [dwr.io](https://dwr.io/) [[RSS](https://dwr.io/feed)]
-- [Emma Wedekind](https://emmawedekind.com/)
+- [Emma Bostian](https://compiled.blog/)
 - [fareez.info](http://fareez.info/)
 - [feather.ca](https://feather.ca)
 - [flaviocopes.com](https://flaviocopes.com/)


### PR DESCRIPTION
Updated the link & name for Emma Bostian's website, [previously Emma Wedekind](https://twitter.com/emmabostian/status/1210494069694066689?lang=en).

