### PR TITLE
Add Toni Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Want a decent RSS reader? I use [NetNewsWire](https://netnewswire.com)
 - [timkadlec.com](https://timkadlec.com/)
 - [Tim Nash](https://timnash.co.uk/) [[RSS](https://timnash.co.uk/feed/)]
 - [TK](https://iamtk.co) [[RSS](https://iamtk.co/rss.xml)]
+- [Toni Notes](https://toninotes.cc/) [[RSS](https://toninotes.cc/feed.xml)]
 - [Peter Thaleikis](https://peterthaleikis.com/) [[RSS](https://peterthaleikis.com/feed.xml)]
 - [Uncle Bob](http://blog.cleancoder.com/) [[RSS](http://blog.cleancoder.com/atom.xml)]
 - [uxcellence.com](https://uxcellence.com) [[RSS](https://uxcellence.com/subscribe)]


### PR DESCRIPTION
Adds Toni Notes (https://toninotes.cc/) and its RSS feed to the list.