### PR TITLE
Add Oleg Timoshin

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Want a decent RSS reader? I use [NetNewsWire](https://netnewswire.com)
 - [notlaura.com](https://notlaura.com)
 - [ohhelloana.blog](https://www.ohhelloana.blog/)
 - [overreacted.io](https://overreacted.io/)
+- [Oleg Timoshin](https://timoshinoleg-eng.github.io/blog/) [[RSS](https://timoshinoleg-eng.github.io/blog/feed.xml)]
 - [paulmcbride.net](https://paulmcbride.net)
 - [Paul Robert Lloyd](https://paulrobertlloyd.com/)
 - [philna.sh](https://philna.sh/)[[RSS](https://philna.sh/feed.xml)]


### PR DESCRIPTION
Adds Oleg Timoshin's tech blog with RSS feed:

URL: https://timoshinoleg-eng.github.io/blog/
RSS: https://timoshinoleg-eng.github.io/blog/feed.xml