### PR TITLE
Add Matt Coles blog (coles.codes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Want a decent RSS reader? I use [NetNewsWire](https://netnewswire.com)
 - [Marius Schulz](https://mariusschulz.com/) [[RSS](http://feeds.feedburner.com/mariusschulz)]
 - [Marko Denic](https://markodenic.com/) [[RSS](https://markodenic.com/feed/)]
 - [Matt Brictson](https://mattbrictson.com/) [[RSS](https://mattbrictson.com/blog.atom)]
+- [Matt Coles](https://coles.codes/) [[RSS](https://coles.codes/index.xml)]
 - [Matt Hagner](https://www.matthagner.com/)
 - [Matt Ouille](https://ooo-yay.com/blog) [[RSS](https://ooo-yay.com/feed.xml)]
 - [Mathias Bynens](https://mathiasbynens.be/notes)


### PR DESCRIPTION
Adds my personal developer blog **coles.codes** with its RSS feed, placed alphabetically in the list.

- [Matt Coles](https://coles.codes/) [[RSS](https://coles.codes/index.xml)]

Principal Engineer at AWS writing about Python, AI agents, local LLMs, and AWS CDK.